### PR TITLE
Fix broken API url for garages

### DIFF
--- a/odp_amsterdam/odp_amsterdam.py
+++ b/odp_amsterdam/odp_amsterdam.py
@@ -131,7 +131,7 @@ class ODPAmsterdam:
             ODPAmsterdamError: If the data is not valid.
         """
         results: list[Garage] = []
-        data = await self._request("dcatd/datasets/9ORkef6T-aU29g/purls/l6HdY0TFamuFOQ")
+        data = await self._request("dcatd/datasets/9ORkef6T-aU29g/purls/1")
 
         for item in data["features"]:
             try:
@@ -153,7 +153,7 @@ class ODPAmsterdam:
         Raises:
             ODPAmsterdamResultsError: When no results are found.
         """
-        data = await self._request("dcatd/datasets/9ORkef6T-aU29g/purls/l6HdY0TFamuFOQ")
+        data = await self._request("dcatd/datasets/9ORkef6T-aU29g/purls/1")
         try:
             result = [item for item in data["features"] if item["Id"] in garage_id]
             return Garage.from_json(result[0])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,7 +19,7 @@ async def test_all_garages(aresponses: ResponsesMockServer) -> None:
     """Test all garage function."""
     aresponses.add(
         "api.data.amsterdam.nl",
-        "/dcatd/datasets/9ORkef6T-aU29g/purls/l6HdY0TFamuFOQ",
+        "/dcatd/datasets/9ORkef6T-aU29g/purls/1",
         "GET",
         aresponses.Response(
             status=200,
@@ -43,7 +43,7 @@ async def test_single_garage(aresponses: ResponsesMockServer) -> None:
     """Test a single garage model."""
     aresponses.add(
         "api.data.amsterdam.nl",
-        "/dcatd/datasets/9ORkef6T-aU29g/purls/l6HdY0TFamuFOQ",
+        "/dcatd/datasets/9ORkef6T-aU29g/purls/1",
         "GET",
         aresponses.Response(
             status=200,
@@ -90,7 +90,7 @@ async def test_wrong_garage_model(aresponses: ResponsesMockServer) -> None:
     """Test a wrong garage model."""
     aresponses.add(
         "api.data.amsterdam.nl",
-        "/dcatd/datasets/9ORkef6T-aU29g/purls/l6HdY0TFamuFOQ",
+        "/dcatd/datasets/9ORkef6T-aU29g/purls/1",
         "GET",
         aresponses.Response(
             status=200,
@@ -110,7 +110,7 @@ async def test_no_garage_found(aresponses: ResponsesMockServer) -> None:
     """Test a wrong garage model."""
     aresponses.add(
         "api.data.amsterdam.nl",
-        "/dcatd/datasets/9ORkef6T-aU29g/purls/l6HdY0TFamuFOQ",
+        "/dcatd/datasets/9ORkef6T-aU29g/purls/1",
         "GET",
         aresponses.Response(
             status=200,


### PR DESCRIPTION
The API url has recently changed, so retrieving the garage data no longer worked.

Related to: https://github.com/home-assistant/core/issues/86207