### PR TITLE
Loosen pytz dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ packages = [
 [tool.poetry.dependencies]
 aiohttp = ">=3.0.0"
 python = "^3.11"
-pytz = "^2023.3"
+pytz = ">=2023.3"
 yarl = ">=1.6.0"
 
 [tool.poetry.urls]


### PR DESCRIPTION
## Proposed change
`pytz` uses CalVer. I.e. the latest release is `2024.01` without any breaking changes.
Loosen the pin to allow for newer versions and easier updates in downstream apps / libraries.

--
Would be awesome if you could release a new version afterwards. This blocks the `pytz` update for Home Assistant, currently.